### PR TITLE
Utilisation du nouveau système d'installation de repo de Debian

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,20 +6,41 @@
       - gnupg2
     state: present
 
-- name: Add Nodesource apt key.
-  apt_key:
-    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
-    id: "68576280"
-    state: present
+- name: Remove old key and source
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - /usr/share/keyrings/nodesource.gpg
+    - /etc/apt/sources.list.d/nodesource.list
+
+- name: Download NodeSource's signing key.
+  get_url:
+    url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
+    dest: /etc/apt/signing-key-nodesource-repo.asc
+    owner: root
+    group: root
+    mode: '0444'
+    force: true
 
 - name: Add NodeSource repositories for Node.js.
   apt_repository:
-    repo: "{{ item }}"
+    filename: "node_{{ nodejs_version }}"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/signing-key-nodesource-repo.asc] https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main"
     state: present
-  with_items:
-    - "deb https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
-    - "deb-src https://deb.nodesource.com/node_{{ nodejs_version }} {{ ansible_distribution_release }} main"
   register: node_repo
+
+- name: Create sources file
+  blockinfile:
+    path: /etc/apt/preferences.d/nodejs
+    create: true
+    owner: root
+    group: root
+    mode: '0444'
+    block: |
+      Package: nodejs
+      Pin: origin deb.nodesource.com
+      Pin-Priority: 600
 
 - name: Update apt cache if repo was added.
   apt: update_cache=yes


### PR DESCRIPTION
## Problème

Depuis sa version `21`, NodeJS ne permet plus une installation via l'ancien système de stockage de clé d'identification de Debian (keyring) et de configuration des repos.

## Solution

Il faut utiliser le nouveau système d'ajout de repo :
- Supprimer les anciennes clés et configurations utilisées par l'ancien système de listes.
- Stocker la nouvelle clé dans un `/etc/apt/`
- Préciser le chemin vers cette clé lors de l'enregistrement du repo.
- Créer une configuration du repo dans `/etc/apt/preferences.d/`.


## Remarque

Ce système d'installation déprécié est encore utilisé pour l'installation de Elasticsearch et PHP.
